### PR TITLE
Properly clone date object to not cause duplicate keys in array

### DIFF
--- a/angular-date-pickable.js
+++ b/angular-date-pickable.js
@@ -36,9 +36,9 @@ function jbDatePickableDirective () {
     updateVisibleDates();
 
     function updateVisibleDates () {
-      vm.visibleDates = [vm.visibleDate];
+      vm.visibleDates = [moment(vm.visibleDate.toDate())];
       for(var i = 1; i < vm.visibleMonths; i++) {
-        vm.visibleDates.push(vm.visibleDate.clone().add(i, 'month').startOf('month'));  
+        vm.visibleDates.push(moment(vm.visibleDate.toDate()).add(i, 'month').startOf('month'));
       }
     }
 


### PR DESCRIPTION
There was an issue in a bigger Angular app where the cloning was causing two objects to have the same hash key, causing an error when repeating over the array of objects.
