### PR TITLE
Multiple start and end dates

### DIFF
--- a/angular-date-pickable.js
+++ b/angular-date-pickable.js
@@ -148,6 +148,10 @@ function jbDatePickableDirective () {
       return false;
     }
 
+    //  The updateSelectedDateRange and updateVisibleDates functions need to be
+    //  debounced because when both the start and end dates are changed at the
+    //  same time, the first watch would stop the second from executing and the
+    //  end date would not be set.
     var debounceUpdateSelectedDateRange = _.debounce(function() {
       updateVisibleDates();
       updateSelectedDateRange();

--- a/angular-date-pickable.js
+++ b/angular-date-pickable.js
@@ -148,13 +148,20 @@ function jbDatePickableDirective () {
       return false;
     }
 
+    var debounceUpdateSelectedDateRange = _.debounce(function() {
+      updateVisibleDates();
+      updateSelectedDateRange();
+    }, 100);
+
     //  Watch for start and end date changes
     $scope.$watch(
       'vm.startDate',
       function(newStartDate, oldStartDate) {
         if (newStartDate !== oldStartDate && newStartDate !== vm.selectStartDate) {
+          vm.visibleDate = moment(vm.startDate).startOf('month');
           vm.selectStartDate = vm.startDate;
-          _.debounce(updateSelectedDateRange, 100)();
+
+          debounceUpdateSelectedDateRange();
         }
       }
     );
@@ -163,8 +170,10 @@ function jbDatePickableDirective () {
       'vm.endDate',
       function(newEndDate, oldEndDate) {
         if (newEndDate !== oldEndDate && newEndDate !== vm.selectEndDate) {
+          vm.visibleDate = moment(vm.endDate).startOf('month');
           vm.selectEndDate = vm.endDate;
-          _.debounce(updateSelectedDateRange, 100)();
+
+          debounceUpdateSelectedDateRange();
         }
       }
     );

--- a/angular-date-pickable.js
+++ b/angular-date-pickable.js
@@ -152,9 +152,9 @@ function jbDatePickableDirective () {
     $scope.$watch(
       'vm.startDate',
       function(newStartDate, oldStartDate) {
-        if (newStartDate !== oldStartDate) {
+        if (newStartDate !== oldStartDate && newStartDate !== vm.selectStartDate) {
           vm.selectStartDate = vm.startDate;
-          _.debounce(updateSelectedDateRange, 100);
+          _.debounce(updateSelectedDateRange, 100)();
         }
       }
     );
@@ -162,7 +162,7 @@ function jbDatePickableDirective () {
     $scope.$watch(
       'vm.endDate',
       function(newEndDate, oldEndDate) {
-        if (newEndDate !== oldEndDate) {
+        if (newEndDate !== oldEndDate && newEndDate !== vm.selectEndDate) {
           vm.selectEndDate = vm.endDate;
           _.debounce(updateSelectedDateRange, 100)();
         }


### PR DESCRIPTION
Added a separate **start** and **end** date to differentiate from when the dates are selected or changed from outside the directive. Also, if the start and/or end date are changed from outside the directive to a month that is not being displayed on the calendar, the visible dates will be changed updated to show the most resent date change.
